### PR TITLE
Allow for date TOML option to get date into LaTeX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-latex"
-version = "0.1.24"
+version = "0.2.0"
 authors = ["lbeckman314 <liam@liambeckman.com>"]
 edition = "2018"
 description = "An mdbook backend for generating LaTeX and PDF documents."

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,3 +1,4 @@
 # Summary
 
 - [README](./README.md)
+    - [Configuration](./configuration.md)

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,0 +1,40 @@
+## Configuration options
+
+In the `[output.latex]` section of book.toml it is possible to set a number of configuration options.
+
+### What gets built and retained
+
+There are three options which determine what files will be built and retained.
+The markdown file is an intermediate step for creating the LaTeX file, which in turn is needed to build the PDF.
+
+By default only the LaTeX file is created and retained.
+The LaTeX file should be processable by tectonic or other TeX engines.
+
+```toml
+[output.latex]
+latex    = true  # default = true
+pdf      = true  # default = false
+markdown = true  # default = false
+```
+### Other options
+
+There are other options which can be used to define how LaTeX file is build
+
+```toml
+[output.latex]
+# list of chapters (as named in the SUMMARY.md) to be ignored when building
+ignores  = ["Introduction", "On UnTeXible Objects"] # default = []
+
+# Custom LaTeX template. It is expected to include a number of LaTeX packages to define the comments
+# that get written to the `.tex` file. Path is relative to the book root directory (typically the same
+# directory this TOML file lives in)
+custom-template = "path/to/my-tempate.tex" # default is None
+
+# date to be used as argument to the \date{} command.
+date = "18 January 2038" # default = "\\today"
+```
+
+Note that when `pdf = true`, the call to process LaTeX file does not pass in the current date or time, so
+the resulting PDF will have a date from the beginning of the Unix Epoch.
+To avoid that you will need to explicitly
+set a date in this configuration or to generate the LaTeX and process that to PDF on your own.

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,9 @@ pub struct LatexConfig {
 
     // Use user's LaTeX template file instead of default (template.tex).
     pub custom_template: Option<String>,
+
+    // Date to be used in the LaTeX \date{} macro
+    pub date: Option<String>,
 }
 
 fn main() -> std::io::Result<()> {
@@ -55,6 +58,8 @@ fn main() -> std::io::Result<()> {
     let title = ctx.config.book.title.unwrap();
     let authors = ctx.config.book.authors.join(" \\and ");
 
+    let date = cfg.date.unwrap_or_default();
+
     // Copy template data into memory.
     let mut template = if let Some(custom_template) = cfg.custom_template {
         let mut custom_template_path = ctx.root;
@@ -64,9 +69,11 @@ fn main() -> std::io::Result<()> {
         include_str!("template.tex").to_string()
     };
 
+
     // Add title and author information.
     template = template.replace(r"\title{}", &format!("\\title{{{}}}", title));
     template = template.replace(r"\author{}", &format!("\\author{{{}}}", authors));
+    template = template.replace(r"\date{}", &format!("\\date{{{}}}", date));
 
     let mut latex = String::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::io::{self, Write};
 use std::path::Path;
 
 // config definition.
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct LatexConfig {
     // Chapters that will not be exported.
@@ -34,6 +34,19 @@ pub struct LatexConfig {
 
     // Date to be used in the LaTeX \date{} macro
     pub date: Option<String>,
+}
+
+impl Default for LatexConfig {
+    fn default() -> Self {
+        Self {
+            ignores: Default::default(),
+            latex: true,
+            pdf: false,
+            markdown: false,
+            custom_template: None,
+            date: Some(r#"\today"#.to_string()),
+        }
+    }
 }
 
 fn main() -> std::io::Result<()> {
@@ -68,7 +81,6 @@ fn main() -> std::io::Result<()> {
     } else {
         include_str!("template.tex").to_string()
     };
-
 
     // Add title and author information.
     template = template.replace(r"\title{}", &format!("\\title{{{}}}", title));

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,14 +185,11 @@ fn relative_path(content: &str, chapter_path: &Path) -> String {
     let mut new_path = String::new();
     let parser = Parser::new_ext(content, Options::empty());
     for event in parser {
-        match event {
-            Event::Start(Tag::Image(_, path, _)) => {
-                new_path.push_str(chapter_path.to_str().unwrap());
-                new_path.push_str("/");
-                new_path.push_str(&path.clone().into_string());
-                new_content = content.replace(&path.into_string(), &new_path);
-            }
-            _ => (),
+        if let Event::Start(Tag::Image(_, path, _)) = event {
+            new_path.push_str(chapter_path.to_str().unwrap());
+            new_path.push_str("/");
+            new_path.push_str(&path.clone().into_string());
+            new_content = content.replace(&path.into_string(), &new_path);
         }
     }
 
@@ -202,6 +199,7 @@ fn relative_path(content: &str, chapter_path: &Path) -> String {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn test_relative_path() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,10 @@ extern crate tectonic;
 use md2tex::markdown_to_tex;
 use mdbook::book::BookItem;
 use mdbook::renderer::RenderContext;
-use std::error::Error;
+use pulldown_cmark::{Event, Options, Parser, Tag};
 use std::fs::{self, File};
 use std::io::{self, Write};
 use std::path::Path;
-use pulldown_cmark::{Event, Options, Parser, Tag};
-use std::path::PathBuf;
 
 // config definition.
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -43,12 +41,14 @@ fn main() -> std::io::Result<()> {
     println!("{:?}", ctx);
 
     // Get configuration options from book.toml.
-    let cfg: LatexConfig = ctx.config
-                              .get_deserialized("output.latex")
-                              .unwrap_or_default();
+    let cfg: LatexConfig = ctx
+        .config
+        .get_deserialized_opt("output.latex")
+        .expect("Error reading \"output.latex\" configuration")
+        .unwrap_or_default();
 
     //if !cfg.latex && !cfg.pdf && !cfg.markdown {
-        //Err("No configurations selected.")
+    //Err("No configurations selected.")
     //}
 
     // Read book's config values (title, authors).
@@ -57,12 +57,12 @@ fn main() -> std::io::Result<()> {
 
     // Copy template data into memory.
     let mut template = if let Some(custom_template) = cfg.custom_template {
-            let mut custom_template_path = ctx.root;
-            custom_template_path.push(custom_template);
-            std::fs::read_to_string(custom_template_path)?
-        } else {
-            include_str!("template.tex").to_string()
-        };
+        let mut custom_template_path = ctx.root;
+        custom_template_path.push(custom_template);
+        std::fs::read_to_string(custom_template_path)?
+    } else {
+        include_str!("template.tex").to_string()
+    };
 
     // Add title and author information.
     template = template.replace(r"\title{}", &format!("\\title{{{}}}", title));
@@ -102,7 +102,12 @@ fn main() -> std::io::Result<()> {
 
     if cfg.latex {
         // Output latex file.
-        output_markdown(".tex".to_string(), title.clone(), &template, &ctx.destination);
+        output_markdown(
+            ".tex".to_string(),
+            title.clone(),
+            &template,
+            &ctx.destination,
+        );
     }
 
     // Output PDF file.
@@ -130,7 +135,12 @@ fn main() -> std::io::Result<()> {
 /// Output plain text file.
 ///
 /// Used for writing markdown and latex data to files.
-fn output_markdown<P: AsRef<Path>>(extension: String, mut filename: String, data: &String, destination: P) {
+fn output_markdown<P: AsRef<Path>>(
+    extension: String,
+    mut filename: String,
+    data: &String,
+    destination: P,
+) {
     filename.push_str(&extension);
     let path = Path::new(&filename);
     let display = path.display();
@@ -139,13 +149,13 @@ fn output_markdown<P: AsRef<Path>>(extension: String, mut filename: String, data
     let _ = fs::create_dir_all(destination);
 
     let mut file = match File::create(&path) {
-        Err(why) => panic!("Couldn't create {}: {}", display, why.description()),
+        Err(why) => panic!("Couldn't create {}: {}", display, why),
         Ok(file) => file,
     };
 
     // Write to file.
     match file.write_all(data.as_bytes()) {
-        Err(why) => panic!("Couldn't write to {}: {}", display, why.description()),
+        Err(why) => panic!("Couldn't write to {}: {}", display, why),
         Ok(_) => println!("Successfully wrote to {}", display),
     }
 }
@@ -163,13 +173,12 @@ fn relative_path(content: &str, chapter_path: &Path) -> String {
                 new_path.push_str(&path.clone().into_string());
                 new_content = content.replace(&path.into_string(), &new_path);
             }
-            _ => ()
+            _ => (),
         }
     }
 
     new_content.to_string()
 }
-
 
 #[cfg(test)]
 mod test {
@@ -183,4 +192,3 @@ mod test {
         assert_eq!("![123](/a/b/c/./xyz.png)", new_content);
     }
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ fn main() -> std::io::Result<()> {
 
     if cfg.latex || cfg.pdf {
         // convert markdown data to LaTeX
-        latex.push_str(&markdown_to_tex(content.to_string()));
+        latex.push_str(&markdown_to_tex(content));
         println!("latex: {}", latex);
 
         // Insert new LaTeX data into template after "%% mdbook-latex begin".
@@ -119,7 +119,7 @@ fn main() -> std::io::Result<()> {
 
         let mut pos = 0;
 
-        let mut file_pdf = title.clone();
+        let mut file_pdf = title;
         file_pdf.push_str(".pdf");
         let mut buffer = File::create(&file_pdf)?;
 
@@ -138,7 +138,7 @@ fn main() -> std::io::Result<()> {
 fn output_markdown<P: AsRef<Path>>(
     extension: String,
     mut filename: String,
-    data: &String,
+    data: &str,
     destination: P,
 ) {
     filename.push_str(&extension);
@@ -177,7 +177,7 @@ fn relative_path(content: &str, chapter_path: &Path) -> String {
         }
     }
 
-    new_content.to_string()
+    new_content
 }
 
 #[cfg(test)]

--- a/src/template.tex
+++ b/src/template.tex
@@ -193,6 +193,7 @@
 %% Title and Author (retreived from book.toml)
 \title{}
 \author{}
+\date{}
 
 %% Begin document.
 \begin{document}


### PR DESCRIPTION
Resolves #6 

`tectonic::latex_to_pdf` does not look at the system time, and so the `\today` TeX macro will use the beginning of the Unix epoch, resulting in documents with dates of January 1, 1970 or December 31, 1969 (depending on time zone).

This allows one to specify a date string in the `[output.latex]` section of the TOML so that, for example,

```toml
[output.latex]
pdf = true
date = "18 January, 2038"
```
could all one to specify a date that would appear as specified in the output's title page.

The changes should be fully backwards compatible. TOMLs that do not specify the date will continue to work as before.

## Documentation change

This also includes a documentation change, illustrating the use of the new configuration option as well as documenting previously undocumented options.

## Code tidy

During the course of working on this, I did some minor tidying of eliminating compiler and clips warnings.