### PR TITLE
Fix images

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,5 @@ mdbook = "0.3.5"
 serde = "1.0.104"
 serde_derive = "1.0.104"
 tectonic = "0.1.12"
-md2tex = "0.1.3"
+md2tex = "0.1.4"
 pulldown-cmark = "0.7.0"
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,6 @@ fn traverse_markdown(content: &str, chapter_path: &Path, context: &RenderContext
                 // creating the path where the image will be copied to
                 let targetimage = context.destination.clone().join(&imagepath);
 
-                println!("Source: {}\nTarget: {}\n", sourceimage.display(), targetimage.display());
                 // creating the directory if neccessary
                 fs::create_dir_all(targetimage.parent().unwrap()).expect("Failure while creating the directories");
                 // copy the image

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,6 @@ fn output_markdown<P: AsRef<Path>>(extension: String, mut filename: String, data
 /// Replace the imagepath with a path that references the source image.
 fn traverse_markdown(content: &str, chapter_path: &Path, context: &RenderContext) -> String {
     let mut new_content = String::from(content);
-    let mut new_path = String::new();
     let parser = Parser::new_ext(content, Options::empty());
     for event in parser {
         match event {
@@ -181,9 +180,6 @@ fn traverse_markdown(content: &str, chapter_path: &Path, context: &RenderContext
                 fs::create_dir_all(targetimage.parent().unwrap()).expect("Failure while creating the directories");
                 // copy the image
                 fs::copy(&sourceimage, &targetimage).expect("Failure while copying the image");
-                new_path.push_str(chapter_path.to_str().unwrap());
-                new_path.push_str("/");
-                new_path.push_str(&path.clone().to_string());
                 new_content = new_content.replace(&path.to_string(), &imagepath.to_str().unwrap());
             }
             _ => ()

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,5 +214,10 @@ mod test {
         );
         let new_content = traverse_markdown(content, &path, &context);
         assert_eq!("![123](images/chap/xyz.png)", new_content);
+        let respath = Path::new("/tmp/dest/images/chap/xyz.png");
+        assert!(respath.exists());
+
+        fs::remove_dir_all("/tmp/test").unwrap();
+        fs::remove_dir_all("/tmp/dest").unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,12 +194,25 @@ fn traverse_markdown(content: &str, chapter_path: &Path, context: &RenderContext
 mod test {
     use super::*;
     use std::path::PathBuf;
+    use std::fs::OpenOptions;
 
     #[test]
     fn test_traverse_markdown() {
+        let imgpath = Path::new("/tmp/test/src/chap/xyz.png");
+        fs::create_dir_all(imgpath.parent().unwrap()).expect("failure while creating testdirs");
+        let _ = match OpenOptions::new().create(true).write(true).open(imgpath) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e),
+        };
         let content = "![123](./xyz.png)";
-        let path = PathBuf::from(r"/a/b/c");
-        let new_content = traverse_markdown(content, &path);
-        assert_eq!("![123](/a/b/c/./xyz.png)", new_content);
+        let path = PathBuf::from(r"chap/");
+        let context = RenderContext::new(
+            Path::new("/tmp/test/"),
+            mdbook::book::Book::new(),
+            mdbook::Config::default(),
+            Path::new("/tmp/dest/")
+        );
+        let new_content = traverse_markdown(content, &path, &context);
+        assert_eq!("![123](images/chap/xyz.png)", new_content);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ fn main() -> io::Result<()> {
     // Get markdown source from the mdbook command via stdin
     let ctx = RenderContext::from_json(&mut stdin).unwrap();
 
+
     // Get configuration options from book.toml.
     let cfg: LatexConfig = ctx.config
                               .get_deserialized_opt("output.latex")
@@ -51,6 +52,7 @@ fn main() -> io::Result<()> {
     // Read book's config values (title, authors).
     let title = ctx.config.book.title.clone().unwrap();
     let authors = ctx.config.book.authors.join(" \\and ");
+
 
     // Copy template data into memory.
     let mut template = if let Some(custom_template) = cfg.custom_template {
@@ -73,7 +75,6 @@ fn main() -> io::Result<()> {
 
         // Iterate through each chapter.
         if let BookItem::Chapter(ref ch) = *item {
-            println!("Subitems: {:#?}", ch.parent_names.len());
             if cfg.ignores.contains(&ch.name) {
                 continue;
             }


### PR DESCRIPTION
This copys images to the target directory and makes therefore the targetdirectory independent from the source directory all the image urls are relative again.

This requires md2tex to be changed: https://github.com/lbeckman314/md2tex/pull/3

This should fix: #5 

The testcase is adjusted however it creates some temporary files in /tmp/ - I don't know if that's the best solution.

