### PR TITLE
Fix images 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,5 @@ mdbook = "0.3.5"
 serde = "1.0.104"
 serde_derive = "1.0.104"
 tectonic = "0.1.12"
-md2tex = "0.1.3"
+md2tex = "0.1.4"
 pulldown-cmark = "0.7.0"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,22 @@
 [package]
-name = "mdbook-latex"
-version = "0.1.24"
 authors = ["lbeckman314 <liam@liambeckman.com>"]
-edition = "2018"
 description = "An mdbook backend for generating LaTeX and PDF documents."
+edition = "2018"
 license = "MPL-2.0"
+name = "mdbook-latex"
 readme = "README.md"
 repository = "https://github.com/lbeckman314/mdbook-latex"
-
+version = "0.1.24"
 [dependencies]
 mdbook = "0.3.5"
+pulldown-cmark = "0.7.0"
+pulldown-cmark-to-cmark = "*"
 serde = "1.0.104"
 serde_derive = "1.0.104"
 tectonic = "0.1.12"
-md2tex = "0.1.4"
-pulldown-cmark = "0.7.0"
+
+[dependencies.md2tex]
+#path = "../md2tex"
+version = "0.1.4"
+git = "https://github.com/enaut/md2tex.git"
+branch = "independent-book"

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,6 @@ fn traverse_markdown(content: &str, chapter_path: &Path, context: &RenderContext
                 // creating the path where the image will be copied to
                 let targetimage = context.destination.clone().join(&imagepath);
 
-                println!("Source: {}\nTarget: {}\n", sourceimage.display(), targetimage.display());
                 // creating the directory if neccessary
                 fs::create_dir_all(targetimage.parent().unwrap()).expect("Failure while creating the directories");
                 // copy the image

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,6 @@ fn output_markdown<P: AsRef<Path>>(extension: String, mut filename: String, data
 /// Replace the imagepath with a path that references the source image.
 fn traverse_markdown(content: &str, chapter_path: &Path, context: &RenderContext) -> String {
     let mut new_content = String::from(content);
-    let mut new_path = String::new();
     let parser = Parser::new_ext(content, Options::empty());
     for event in parser {
         match event {
@@ -181,9 +180,6 @@ fn traverse_markdown(content: &str, chapter_path: &Path, context: &RenderContext
                 fs::create_dir_all(targetimage.parent().unwrap()).expect("Failure while creating the directories");
                 // copy the image
                 fs::copy(&sourceimage, &targetimage).expect("Failure while copying the image");
-                new_path.push_str(chapter_path.to_str().unwrap());
-                new_path.push_str("/");
-                new_path.push_str(&path.clone().to_string());
                 new_content = new_content.replace(&path.to_string(), &imagepath.to_str().unwrap());
             }
             _ => ()

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,5 +214,10 @@ mod test {
         );
         let new_content = traverse_markdown(content, &path, &context);
         assert_eq!("![123](images/chap/xyz.png)", new_content);
+        let respath = Path::new("/tmp/dest/images/chap/xyz.png");
+        assert!(respath.exists());
+
+        fs::remove_dir_all("/tmp/test").unwrap();
+        fs::remove_dir_all("/tmp/dest").unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,12 +194,25 @@ fn traverse_markdown(content: &str, chapter_path: &Path, context: &RenderContext
 mod test {
     use super::*;
     use std::path::PathBuf;
+    use std::fs::OpenOptions;
 
     #[test]
     fn test_traverse_markdown() {
+        let imgpath = Path::new("/tmp/test/src/chap/xyz.png");
+        fs::create_dir_all(imgpath.parent().unwrap()).expect("failure while creating testdirs");
+        let _ = match OpenOptions::new().create(true).write(true).open(imgpath) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e),
+        };
         let content = "![123](./xyz.png)";
-        let path = PathBuf::from(r"/a/b/c");
-        let new_content = traverse_markdown(content, &path);
-        assert_eq!("![123](/a/b/c/./xyz.png)", new_content);
+        let path = PathBuf::from(r"chap/");
+        let context = RenderContext::new(
+            Path::new("/tmp/test/"),
+            mdbook::book::Book::new(),
+            mdbook::Config::default(),
+            Path::new("/tmp/dest/")
+        );
+        let new_content = traverse_markdown(content, &path, &context);
+        assert_eq!("![123](images/chap/xyz.png)", new_content);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ fn main() -> io::Result<()> {
     // Get markdown source from the mdbook command via stdin
     let ctx = RenderContext::from_json(&mut stdin).unwrap();
 
+
     // Get configuration options from book.toml.
     let cfg: LatexConfig = ctx.config
                               .get_deserialized_opt("output.latex")
@@ -51,6 +52,7 @@ fn main() -> io::Result<()> {
     // Read book's config values (title, authors).
     let title = ctx.config.book.title.clone().unwrap();
     let authors = ctx.config.book.authors.join(" \\and ");
+
 
     // Copy template data into memory.
     let mut template = if let Some(custom_template) = cfg.custom_template {
@@ -73,7 +75,6 @@ fn main() -> io::Result<()> {
 
         // Iterate through each chapter.
         if let BookItem::Chapter(ref ch) = *item {
-            println!("Subitems: {:#?}", ch.parent_names.len());
             if cfg.ignores.contains(&ch.name) {
                 continue;
             }


### PR DESCRIPTION
This suggestion improves on the previous pullrequest.

If in any part of the book the url of an image had been written outside of an image tag or as part of another image or as part of something else. the replace would have replaced it with something else. Therefor the replace solution is not optimal.

In this version the markdown parser is actually used to change the parsed markdown. Then this parser is written back to the markdown string. The string is then processed the same as `new_content` before.

I also added the dependency to the branch in my git repository so this hopefully compiles in the CI.

A further thought would be to merge md2tex into the lib.rs of mdbook-latex as both are not complex and some parsing and reparsing and context could be handled much easier.

PS: I just read the rustbook and are new to rust too. So there might be things that I did weird or redundant. Happy if you spot anything.

obsoletes: #9 
fixes: #5 