### PR TITLE
Test traverse_markdown with multiple images

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -239,15 +239,21 @@ mod test {
 
     #[test]
     fn test_traverse_markdown() {
-        let imgpath = Path::new("/tmp/test/src/chap/xyz.png");
-        // create a temporary directory in /tmp/
-        fs::create_dir_all(imgpath.parent().unwrap()).expect("failure while creating testdirs");
-        // touch the mock png file
-        let _ = match OpenOptions::new().create(true).write(true).open(imgpath) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e),
-        };
-        let content = "![123](./xyz.png)";
+        let paths = [
+            Path::new("/tmp/test/src/chap/abc.png"),
+            Path::new("/tmp/test/src/chap/xyz.png"),
+        ];
+        for p in paths.iter() {
+            // create a temporary directory in /tmp/
+            fs::create_dir_all(p.parent().unwrap()).expect("failure while creating testdirs");
+            // touch the mock png file
+            let _ = match OpenOptions::new().create(true).write(true).open(p) {
+                Ok(_) => Ok(()),
+                Err(e) => Err(e),
+            };
+        }
+
+        let content = "![123](./xyz.png)\n![456](./abc.png)";
         let path = PathBuf::from(r"chap/");
         let context = RenderContext::new(
             Path::new("/tmp/test/"),
@@ -256,7 +262,10 @@ mod test {
             Path::new("/tmp/dest/")
         );
         let new_content = traverse_markdown(content, &path, &context);
-        assert_eq!("![123](images/chap/xyz.png)", new_content);
+        assert_eq!(
+            "![123](images/chap/xyz.png)\n![456](images/chap/abc.png)",
+            new_content
+        );
         let respath = Path::new("/tmp/dest/images/chap/xyz.png");
         assert!(respath.exists());
 


### PR DESCRIPTION
To prevent regression from former bug which prevented having multiple images in the same markdown.